### PR TITLE
Add Docker containerization with REST API shims for PVE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,6 @@
 # SVG NOTIFICATION CONFIGURATION
 # ============================================================================
 
-
 # Path to the SVG template file
 # Default: <script_directory>/templates/svg/update-nag-template.svg
 # SVG_IMAGE_TEMPLATE=/path/to/custom/template.svg

--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,35 @@
 # WEBHOOK_SERVICE=pve-virtio-webhook.service
 
 # ============================================================================
+# CONTAINER MODE CONFIGURATION
+# Set CONTAINER_MODE=true when running inside Docker.
+# pvesh and qm are replaced by the pve-api.func shims (copied into lib/ by the
+# Dockerfile). On bare-metal PVE hosts, leave this unset or set to false.
+# ============================================================================
+
+# Enable container mode (true/false)
+# CONTAINER_MODE=true
+
+# Proxmox VE REST API endpoint (required in container mode)
+# Create an API token in PVE: Datacenter → Permissions → API Tokens → Add
+# The token must have VM.Audit + VM.Config.Options + VM.GuestAgent privileges.
+# PVE_HOST=https://pve.example.com:8006
+# PVE_PORT=8006
+# PVE_API_TOKEN_ID=root@pam!updater
+# PVE_API_TOKEN_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# Base URL for nag SVG images (must be reachable by the PVE web UI browser).
+# In container mode this should point to the Caddy endpoint serving /app/images.
+# On bare metal the default /pve2/images (served directly by PVE) is used.
+# NAG_IMAGE_BASE_URL=http://updater.example.com:8080
+
+# Path inside the container where SVG images are written (served by Caddy).
+# SVG_IMAGE_PATH=/app/images
+
+# How often to re-run the update check (seconds). Default: 3600 (1 hour).
+# UPDATER_INTERVAL=3600
+
+# ============================================================================
 # ADVANCED CONFIGURATION FOR LOGGING (I recommend leaving these as defaults)
 # ============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -103,10 +103,21 @@
 # Proxmox VE REST API endpoint (required in container mode)
 # Create an API token in PVE: Datacenter → Permissions → API Tokens → Add
 # The token must have VM.Audit + VM.Config.Options + VM.GuestAgent privileges.
-# PVE_HOST=https://pve.example.com:8006
+# PVE_HOST=pve.example.com
 # PVE_PORT=8006
 # PVE_API_TOKEN_ID=root@pam!updater
 # PVE_API_TOKEN_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# TLS verification for the Proxmox API connection.
+# Set PVE_TLS_INSECURE=true to skip certificate verification (self-signed certs).
+# Or set PVE_CA_BUNDLE to verify against a custom CA bundle instead.
+# Leave both unset to use the system trust store (recommended for production).
+# PVE_TLS_INSECURE=false
+# PVE_CA_BUNDLE=/etc/ssl/certs/my-ca.pem
+
+# Timeouts for Proxmox API requests (seconds).
+# PVE_API_CONNECT_TIMEOUT=10
+# PVE_API_MAX_TIME=30
 
 # Base URL for nag SVG images (must be reachable by the PVE web UI browser).
 # In container mode this should point to the Caddy endpoint serving /app/images.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CLAUDE.md
 email.txt
 .claude/
 AGENTS.md
+.DS_Store

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,24 @@
+# Caddyfile — serves SVG nag images produced by the updater container.
+#
+# Usage:
+#   - Development / LAN:  keep ":80" as-is; access via http://host:8080/update-100.svg
+#   - HTTPS (public):     replace ":80" with your domain name and Caddy will obtain
+#                         a certificate automatically (e.g. "updater.example.com { ... }")
+#
+# Set NAG_IMAGE_BASE_URL=http://<this-host>:8080 in .env so the updater writes
+# that URL into Proxmox VM descriptions.
+
+:80 {
+    root * /srv/images
+    file_server
+    encode gzip
+
+    # Optional: restrict access to the Proxmox subnet only
+    # @proxmox_subnet {
+    #     remote_ip 192.168.1.0/24
+    # }
+    # handle @proxmox_subnet {
+    #     file_server
+    # }
+    # respond 403
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     curl \
+    ca-certificates \
     jq \
     grep \
     sed \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm-slim
+
+# Install runtime dependencies.
+# curl + jq: used by check-vm-updates.sh and pve-api.func
+# cron: schedules check-vm-updates.sh runs
+# All other tools (grep, sed, gawk, sort, coreutils) are standard Debian slim packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    curl \
+    jq \
+    grep \
+    sed \
+    gawk \
+    coreutils \
+    cron \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy application source
+COPY . /app/
+
+# Copy the container-only API shim into lib/ so check-vm-updates.sh's
+# "for lib_file in $LIB_DIR/*.func" glob picks it up automatically.
+# On bare-metal installs this file never exists in lib/; no guards needed.
+COPY docker/lib/pve-api.func /app/lib/pve-api.func
+
+# Create runtime directories (these are also mounted as volumes in compose,
+# but must exist for builds without mounts).
+RUN mkdir -p /app/images /app/logs /app/.state
+
+# Make all scripts executable
+RUN chmod +x \
+    /app/check-vm-updates.sh \
+    /app/vm-update.sh \
+    /app/entrypoint.sh \
+    && chmod +x /app/lib/*.func 2>/dev/null || true
+
+# SVG image server port (Caddy reverse-proxies to this)
+EXPOSE 8080
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN chmod +x \
     && chmod +x /app/lib/*.func 2>/dev/null || true
 
 # SVG image server port (Caddy reverse-proxies to this)
-EXPOSE 8080
+# EXPOSE 8080
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  updater:
+    build: .
+    container_name: pve-virtio-updater
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - ./.state:/app/.state
+      - ./logs:/app/logs
+      - ./webhook:/app/webhook
+      - images:/app/images      # shared with caddy
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: pve-virtio-caddy
+    restart: unless-stopped
+    ports:
+      - "${CADDY_PORT:-8080}:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - images:/srv/images:ro   # read the SVGs written by updater
+    depends_on:
+      - updater
+
+volumes:
+  images:

--- a/docker/lib/pve-api.func
+++ b/docker/lib/pve-api.func
@@ -26,6 +26,24 @@ if [[ "${CONTAINER_MODE:-false}" != "true" ]]; then
     return 0
 fi
 
+# Guard: fail early in container mode if required API environment is missing.
+# Use defaulted expansion so this remains safe when the parent script enables `set -u`.
+_pve_required_env=(PVE_HOST PVE_API_TOKEN_ID PVE_API_TOKEN_SECRET)
+_pve_missing_env=()
+_pve_var_name=""
+for _pve_var_name in "${_pve_required_env[@]}"; do
+    if [[ -z "${!_pve_var_name:-}" ]]; then
+        _pve_missing_env+=("$_pve_var_name")
+    fi
+done
+unset _pve_var_name
+if (( ${#_pve_missing_env[@]} > 0 )); then
+    printf 'FATAL: docker/lib/pve-api.func requires the following environment variable(s) in container mode: %s\n' \
+        "${_pve_missing_env[*]}" >&2
+    return 1
+fi
+unset _pve_required_env _pve_missing_env
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -33,6 +51,9 @@ fi
 # @function _pve_api_request
 # @description Core HTTP request against the Proxmox REST API.
 #              Authenticates with PVEAPIToken header.
+#              TLS certificates are verified by default. Set
+#              PVE_TLS_INSECURE=true to explicitly disable verification,
+#              or set PVE_CA_BUNDLE to use a custom CA bundle.
 # @args method  — GET | POST | PUT
 #       path    — API path, e.g. /nodes (without /api2/json prefix)
 #       [body]  — optional URL-encoded body string for POST/PUT
@@ -44,20 +65,53 @@ _pve_api_request() {
 
     local base_url="https://${PVE_HOST}:${PVE_PORT:-8006}/api2/json"
     local auth_header="Authorization: PVEAPIToken=${PVE_API_TOKEN_ID}=${PVE_API_TOKEN_SECRET}"
+    local connect_timeout="${PVE_API_CONNECT_TIMEOUT:-10}"
+    local max_time="${PVE_API_MAX_TIME:-30}"
+
+    local response_file stderr_file http_code curl_exit response_body stderr_body
+    response_file="$(mktemp)"
+    stderr_file="$(mktemp)"
 
     local curl_args=(
-        -s -k
+        -s
+        --fail-with-body
+        --connect-timeout "$connect_timeout"
+        --max-time "$max_time"
         -X "$method"
         -H "$auth_header"
         -H "Content-Type: application/x-www-form-urlencoded"
+        -o "$response_file"
+        -w "%{http_code}"
         "${base_url}${path}"
     )
+
+    if [[ "${PVE_TLS_INSECURE:-false}" == "true" ]]; then
+        curl_args+=(-k)
+    elif [[ -n "${PVE_CA_BUNDLE:-}" ]]; then
+        curl_args+=(--cacert "$PVE_CA_BUNDLE")
+    fi
 
     if [[ -n "$body" ]]; then
         curl_args+=(--data "$body")
     fi
 
-    curl "${curl_args[@]}"
+    http_code="$(curl "${curl_args[@]}" 2>"$stderr_file")"
+    curl_exit=$?
+    response_body="$(cat "$response_file")"
+    stderr_body="$(cat "$stderr_file")"
+    rm -f "$response_file" "$stderr_file"
+
+    if (( curl_exit != 0 )); then
+        if declare -F log_error >/dev/null 2>&1; then
+            log_error "PVE API request failed: ${method} ${path} (HTTP ${http_code:-000}): ${response_body:-$stderr_body}"
+        else
+            printf 'ERROR: PVE API request failed: %s %s (HTTP %s): %s\n' \
+                "$method" "$path" "${http_code:-000}" "${response_body:-$stderr_body}" >&2
+        fi
+        return 1
+    fi
+
+    printf '%s' "$response_body"
 }
 
 # @function _pve_api_get
@@ -230,11 +284,21 @@ function qm() {
             while [[ $# -gt 0 ]]; do
                 case "$1" in
                     -description)
+                        if [[ $# -lt 2 || "$2" == -* ]]; then
+                            log_error "pve-api.func qm shim: missing value for -description"
+                            return 1
+                        fi
                         description="$2"
                         shift 2
                         ;;
+
+                    -*)
+                        log_error "pve-api.func qm shim: unsupported option '$1' for 'qm set'"
+                        return 1
+                        ;;
                     *)
-                        shift
+                        log_error "pve-api.func qm shim: unexpected argument '$1' for 'qm set'"
+                        return 1
                         ;;
                 esac
             done

--- a/docker/lib/pve-api.func
+++ b/docker/lib/pve-api.func
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# Module: pve-api.func (PVE-QEMU-VirtIO-Updater)
+# Description: Bash function shims for pvesh and qm that call the Proxmox REST API
+#              over HTTPS. Loaded only inside the Docker container (the Dockerfile copies
+#              this file into /app/lib/, where check-vm-updates.sh's glob picks it up).
+#              On bare-metal PVE hosts this file never exists in lib/, so pvesh/qm
+#              system binaries are used as-is without any conditional logic.
+#
+# Author: Frederik S. (fs1n) and PVE-QEMU-VirtIO-Updater Contributors
+# Date: 2026-04-14
+#
+# Dependencies: curl, jq
+# Environment: PVE_HOST, PVE_PORT (default 8006), PVE_API_TOKEN_ID, PVE_API_TOKEN_SECRET,
+#              CONTAINER_MODE (must be "true" for shims to activate)
+# Usage: automatically sourced inside the container — do not source manually on bare metal
+#
+# Functions (all internal — called by their same-named system binary counterparts):
+#   pvesh  — mirrors: pvesh get <path> [--output-format json]
+#   qm     — mirrors: qm guest exec <vmid> -- <cmd> [args...]
+#             and:    qm set <vmid> -description <value>
+
+# Guard: do nothing if not in container mode (shouldn't happen since this file is only
+# present in lib/ inside the container, but belt-and-suspenders).
+if [[ "${CONTAINER_MODE:-false}" != "true" ]]; then
+    return 0
+fi
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# @function _pve_api_request
+# @description Core HTTP request against the Proxmox REST API.
+#              Authenticates with PVEAPIToken header.
+# @args method  — GET | POST | PUT
+#       path    — API path, e.g. /nodes (without /api2/json prefix)
+#       [body]  — optional URL-encoded body string for POST/PUT
+# @returns Raw JSON response from the API (full envelope including "data" key)
+_pve_api_request() {
+    local method="$1"
+    local path="$2"
+    local body="${3:-}"
+
+    local base_url="https://${PVE_HOST}:${PVE_PORT:-8006}/api2/json"
+    local auth_header="Authorization: PVEAPIToken=${PVE_API_TOKEN_ID}=${PVE_API_TOKEN_SECRET}"
+
+    local curl_args=(
+        -s -k
+        -X "$method"
+        -H "$auth_header"
+        -H "Content-Type: application/x-www-form-urlencoded"
+        "${base_url}${path}"
+    )
+
+    if [[ -n "$body" ]]; then
+        curl_args+=(--data "$body")
+    fi
+
+    curl "${curl_args[@]}"
+}
+
+# @function _pve_api_get
+# @description GET a PVE API path; returns the unwrapped .data value (matches pvesh output).
+# @args path — e.g. /nodes
+_pve_api_get() {
+    local path="$1"
+    _pve_api_request GET "$path" | jq '.data'
+}
+
+# @function _pve_api_put
+# @description PUT to a PVE API path with a URL-encoded body.
+# @args path — e.g. /nodes/pve/qemu/100/config
+#       body — URL-encoded key=value pairs
+_pve_api_put() {
+    local path="$1"
+    local body="$2"
+    _pve_api_request PUT "$path" "$body"
+}
+
+# @function _pve_api_post
+# @description POST to a PVE API path with a URL-encoded body; returns .data.
+# @args path — e.g. /nodes/pve/qemu/100/agent/exec
+#       body — URL-encoded key=value pairs
+_pve_api_post() {
+    local path="$1"
+    local body="$2"
+    _pve_api_request POST "$path" "$body" | jq '.data'
+}
+
+# @function _pve_node_for_vmid
+# @description Look up the node a VM lives on using the global $windows_vms JSON.
+# @args vmid
+# @returns node name string, or empty string if not found
+_pve_node_for_vmid() {
+    local vmid="$1"
+    echo "$windows_vms" | jq -r --arg vmid "$vmid" '.[$vmid].node // empty'
+}
+
+# @function _pve_url_encode
+# @description Percent-encode a string for use in POST/PUT bodies.
+# @args value
+_pve_url_encode() {
+    printf '%s' "$1" | curl -Gso /dev/null -w "%{url_effective}" --data-urlencode @- "" | cut -c3-
+}
+
+# ---------------------------------------------------------------------------
+# pvesh shim
+# ---------------------------------------------------------------------------
+
+# @function pvesh
+# @description Drop-in replacement for the pvesh CLI when running in a container.
+#              Supports: pvesh get <path> [--output-format json] [ignored flags...]
+#              Outputs unwrapped .data JSON, identical to pvesh --output-format json.
+# @example
+#   pvesh get /nodes --output-format json
+function pvesh() {
+    local subcommand="$1"
+    shift
+
+    case "$subcommand" in
+        get)
+            local path="$1"
+            # Remaining args (e.g., --output-format json) are consumed for compat; output is always JSON
+            _pve_api_get "$path"
+            ;;
+        *)
+            log_error "pve-api.func pvesh shim: unsupported subcommand '$subcommand'"
+            return 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# qm shim
+# ---------------------------------------------------------------------------
+
+# @function qm
+# @description Drop-in replacement for the qm CLI when running in a container.
+#              Supports two call patterns:
+#                qm guest exec <vmid> -- <program> [args...]
+#                qm set <vmid> -description <value>
+#
+#              guest exec: POSTs to /agent/exec, polls /agent/exec-status until
+#              exited=1, then emits {"out-data":"...","err-data":"...","exitcode":N}
+#              — identical shape to real qm guest exec output.
+#
+#              set -description: PUTs the new description to /config.
+# @example
+#   qm guest exec 100 -- powershell.exe -Command 'Get-Date'
+#   qm set 100 -description "my description"
+function qm() {
+    local subcommand="$1"
+    shift
+
+    case "$subcommand" in
+        guest)
+            local guest_subcmd="$1"; shift
+            case "$guest_subcmd" in
+                exec)
+                    local vmid="$1"; shift
+                    # Consume separator "--" if present
+                    [[ "${1:-}" == "--" ]] && shift
+
+                    local node
+                    node=$(_pve_node_for_vmid "$vmid")
+                    if [[ -z "$node" ]]; then
+                        log_error "pve-api.func qm shim: cannot resolve node for vmid $vmid"
+                        return 1
+                    fi
+
+                    # Build JSON array of command + args
+                    local cmd_json
+                    cmd_json=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+
+                    # POST exec — body: command=["prog","arg1",...]
+                    local exec_body
+                    exec_body="command=$(_pve_url_encode "$cmd_json")&input-data="
+
+                    local exec_resp
+                    exec_resp=$(_pve_api_post "/nodes/${node}/qemu/${vmid}/agent/exec" "$exec_body")
+
+                    local pid
+                    pid=$(echo "$exec_resp" | jq -r '.pid // empty')
+                    if [[ -z "$pid" ]]; then
+                        log_error "pve-api.func qm shim: agent/exec did not return a pid"
+                        return 1
+                    fi
+
+                    # Poll exec-status until exited
+                    local max_polls=60
+                    local poll_count=0
+                    local status_resp exited
+
+                    while true; do
+                        sleep 1
+                        status_resp=$(_pve_api_get "/nodes/${node}/qemu/${vmid}/agent/exec-status?pid=${pid}")
+                        exited=$(echo "$status_resp" | jq -r '.exited // 0')
+
+                        if [[ "$exited" == "1" ]]; then
+                            break
+                        fi
+
+                        (( poll_count++ ))
+                        if (( poll_count >= max_polls )); then
+                            log_error "pve-api.func qm shim: guest exec timed out for vmid $vmid"
+                            return 1
+                        fi
+                    done
+
+                    # Emit result in the same shape as real qm guest exec
+                    echo "$status_resp" | jq '{
+                        "out-data": (."out-data" // ""),
+                        "err-data": (."err-data" // ""),
+                        "exitcode": (.exitcode // 0)
+                    }'
+                    ;;
+                *)
+                    log_error "pve-api.func qm shim: unsupported guest subcommand '$guest_subcmd'"
+                    return 1
+                    ;;
+            esac
+            ;;
+
+        set)
+            local vmid="$1"; shift
+
+            # Parse -description <value>
+            local description=""
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    -description)
+                        description="$2"
+                        shift 2
+                        ;;
+                    *)
+                        shift
+                        ;;
+                esac
+            done
+
+            local node
+            node=$(_pve_node_for_vmid "$vmid")
+            if [[ -z "$node" ]]; then
+                log_error "pve-api.func qm shim: cannot resolve node for vmid $vmid"
+                return 1
+            fi
+
+            local body
+            body="description=$(_pve_url_encode "$description")"
+            _pve_api_put "/nodes/${node}/qemu/${vmid}/config" "$body" > /dev/null
+            ;;
+
+        *)
+            log_error "pve-api.func qm shim: unsupported subcommand '$subcommand'"
+            return 1
+            ;;
+    esac
+}

--- a/docker/lib/pve-api.func
+++ b/docker/lib/pve-api.func
@@ -142,6 +142,62 @@ _pve_api_post() {
     _pve_api_request POST "$path" "$body" | jq '.data'
 }
 
+# @function _pve_api_post_json
+# @description POST to a PVE API path with a JSON body; returns .data.
+# @args path — e.g. /nodes/pve/qemu/100/agent/exec
+#       json_body — raw JSON string
+_pve_api_post_json() {
+    local path="$1"
+    local json_body="$2"
+
+    local base_url="https://${PVE_HOST}:${PVE_PORT:-8006}/api2/json"
+    local auth_header="Authorization: PVEAPIToken=${PVE_API_TOKEN_ID}=${PVE_API_TOKEN_SECRET}"
+    local connect_timeout="${PVE_API_CONNECT_TIMEOUT:-10}"
+    local max_time="${PVE_API_MAX_TIME:-30}"
+
+    local response_file stderr_file http_code curl_exit response_body stderr_body
+    response_file="$(mktemp)"
+    stderr_file="$(mktemp)"
+
+    local curl_args=(
+        -s
+        --fail-with-body
+        --connect-timeout "$connect_timeout"
+        --max-time "$max_time"
+        -X POST
+        -H "$auth_header"
+        -H "Content-Type: application/json"
+        -o "$response_file"
+        -w "%{http_code}"
+        --data "$json_body"
+        "${base_url}${path}"
+    )
+
+    if [[ "${PVE_TLS_INSECURE:-false}" == "true" ]]; then
+        curl_args+=(-k)
+    elif [[ -n "${PVE_CA_BUNDLE:-}" ]]; then
+        curl_args+=(--cacert "$PVE_CA_BUNDLE")
+    fi
+
+    http_code="$(curl "${curl_args[@]}" 2>"$stderr_file")"
+    curl_exit=$?
+    response_body="$(cat "$response_file")"
+    stderr_body="$(cat "$stderr_file")"
+    rm -f "$response_file" "$stderr_file"
+
+    if (( curl_exit != 0 )); then
+        if declare -F log_error >/dev/null 2>&1; then
+            log_error "PVE API request failed: POST ${path} (HTTP ${http_code:-000}): ${response_body:-$stderr_body}"
+        else
+            printf 'ERROR: PVE API request failed: POST %s (HTTP %s): %s\n' \
+                "$path" "${http_code:-000}" "${response_body:-$stderr_body}" >&2
+        fi
+        return 1
+    fi
+
+    printf '%s' "$response_body" | jq '.data'
+}
+
 # @function _pve_node_for_vmid
 # @description Look up the node a VM lives on using the global $windows_vms JSON.
 # @args vmid
@@ -155,7 +211,7 @@ _pve_node_for_vmid() {
 # @description Percent-encode a string for use in POST/PUT bodies.
 # @args value
 _pve_url_encode() {
-    printf '%s' "$1" | curl -Gso /dev/null -w "%{url_effective}" --data-urlencode @- "" | cut -c3-
+    printf '%s' "$1" | curl -Gso /dev/null -w "%{url_effective}" --data-urlencode @- "http://x" | cut -c10-
 }
 
 # ---------------------------------------------------------------------------
@@ -227,12 +283,12 @@ function qm() {
                     local cmd_json
                     cmd_json=$(printf '%s\n' "$@" | jq -R . | jq -s .)
 
-                    # POST exec — body: command=["prog","arg1",...]
+                    # POST exec with JSON body: {"command":["prog","arg1",...],"input-data":""}
                     local exec_body
-                    exec_body="command=$(_pve_url_encode "$cmd_json")&input-data="
+                    exec_body=$(jq -n --argjson command "$cmd_json" '{command: $command, "input-data": ""}')
 
                     local exec_resp
-                    exec_resp=$(_pve_api_post "/nodes/${node}/qemu/${vmid}/agent/exec" "$exec_body")
+                    exec_resp=$(_pve_api_post_json "/nodes/${node}/qemu/${vmid}/agent/exec" "$exec_body")
 
                     local pid
                     pid=$(echo "$exec_resp" | jq -r '.pid // empty')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# entrypoint.sh — Docker container startup for PVE-QEMU-VirtIO-Updater
+#
+# Runs check-vm-updates.sh on a configurable interval (UPDATER_INTERVAL seconds,
+# default 3600). The loop executes once immediately on startup, then sleeps.
+# Errors in check-vm-updates.sh are logged but do not stop the loop.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+INTERVAL="${UPDATER_INTERVAL:-3600}"
+
+# Ensure runtime directories exist (volumes may overlay these, so recreate if needed)
+mkdir -p "${SCRIPT_DIR}/images" "${SCRIPT_DIR}/logs" "${SCRIPT_DIR}/.state"
+
+echo "[entrypoint] PVE-QEMU-VirtIO-Updater container starting"
+echo "[entrypoint] Update interval: ${INTERVAL}s"
+echo "[entrypoint] PVE host: ${PVE_HOST:-<not set>}"
+echo "[entrypoint] NAG_IMAGE_BASE_URL: ${NAG_IMAGE_BASE_URL:-<not set>}"
+
+while true; do
+    echo "[entrypoint] Running check-vm-updates.sh at $(date '+%Y-%m-%d %H:%M:%S')"
+    "${SCRIPT_DIR}/check-vm-updates.sh" || echo "[entrypoint] check-vm-updates.sh exited with error $?"
+    echo "[entrypoint] Sleeping ${INTERVAL}s until next run"
+    sleep "$INTERVAL"
+done

--- a/lib/default.func
+++ b/lib/default.func
@@ -48,19 +48,40 @@ function check_script_dependencies() {
 #   latest_ver=$(echo "$version_json" | jq -r '.version')
 fetch_latest_virtio_version() {
     local FEDORA_PEOPLE_ARCHIVE_ROOT_URL="https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/"
+    local max_retries=3
+    local retry_count=0
+    local archive_page http_code page_content latest_json
 
-    # Use curl and capture status code
-    local archive_page
-    archive_page=$(curl -sS -w "\n%{http_code}" "${FEDORA_PEOPLE_ARCHIVE_ROOT_URL}") || {
-        log_error "Failed to fetch Fedora People Archive page"
-    }
+    # Retry logic for network failures
+    while (( retry_count < max_retries )); do
+        # Use curl and capture status code
+        archive_page=$(curl -sS --max-time 10 -w "\n%{http_code}" "${FEDORA_PEOPLE_ARCHIVE_ROOT_URL}") || {
+            log_warn "Failed to fetch Fedora People Archive page (attempt $((retry_count + 1))/$max_retries)"
+            (( retry_count++ ))
+            sleep 2
+            continue
+        }
 
-    local http_code=$(echo "$archive_page" | tail -n1)
-    # Use sed to remove the last line (the http code)
-    local page_content=$(echo "$archive_page" | sed '$d')
+        http_code=$(echo "$archive_page" | tail -n1)
+        # Use sed to remove the last line (the http code)
+        page_content=$(echo "$archive_page" | sed '$d')
 
-    if [ "$http_code" != "200" ]; then
-        log_error "Failed to access Fedora People Archive. HTTP Status: ${http_code}"
+        if [ "$http_code" != "200" ]; then
+            log_warn "Failed to access Fedora People Archive. HTTP Status: ${http_code} (attempt $((retry_count + 1))/$max_retries)"
+            (( retry_count++ ))
+            sleep 2
+            continue
+        fi
+
+        # Success, break out of retry loop
+        break
+    done
+
+    # If we exhausted retries and still have no content, log error and return empty
+    if [ -z "$page_content" ]; then
+        log_error "Could not fetch Fedora People Archive after $max_retries attempts"
+        echo '{"version":"","release":""}'
+        return 0
     fi
 
     # Refactored AWK to be compatible with mawk and gawk
@@ -90,7 +111,9 @@ fetch_latest_virtio_version() {
     )
 
     if [ -z "$latest_json" ]; then
-        log_error "Could not find any virtio-win directory versions"
+        log_error "Could not find any virtio-win directory versions in Fedora Archive"
+        echo '{"version":"","release":""}'
+        return 0
     fi
 
     echo "$latest_json"
@@ -105,32 +128,53 @@ fetch_latest_virtio_version() {
 #   latest_qemu=$(echo "$qemu_json" | jq -r '.version')
 fetch_latest_qemu_ga_version() {
     local FEDORA_PEOPLE_ARCHIVE_ROOT_URL="https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/"
+    local max_retries=3
+    local retry_count=0
+    local archive_page http_code page_content latest_json
 
-    # Abruf der Seite und des HTTP-Statuscodes
-    local archive_page
-    archive_page=$(curl -sS -w "\n%{http_code}" "${FEDORA_PEOPLE_ARCHIVE_ROOT_URL}") || {
-        log_error "Failed to fetch Fedora People Archive page"
-    }
+    # Retry logic for network failures
+    while (( retry_count < max_retries )); do
+        # Fetch the page and capture status code
+        archive_page=$(curl -sS --max-time 10 -w "\n%{http_code}" "${FEDORA_PEOPLE_ARCHIVE_ROOT_URL}") || {
+            log_warn "Failed to fetch Fedora People Archive page (attempt $((retry_count + 1))/$max_retries)"
+            (( retry_count++ ))
+            sleep 2
+            continue
+        }
 
-    local http_code=$(echo "$archive_page" | tail -n1)
-    # Entferne die letzte Zeile (den Statuscode) sicher mit sed
-    local page_content=$(echo "$archive_page" | sed '$d')
+        http_code=$(echo "$archive_page" | tail -n1)
+        # Remove the last line (the status code) safely with sed
+        page_content=$(echo "$archive_page" | sed '$d')
 
-    if [ "$http_code" != "200" ]; then
-        log_error "Failed to access Fedora People Archive. HTTP Status: ${http_code}"
+        if [ "$http_code" != "200" ]; then
+            log_warn "Failed to access Fedora People Archive. HTTP Status: ${http_code} (attempt $((retry_count + 1))/$max_retries)"
+            (( retry_count++ ))
+            sleep 2
+            continue
+        fi
+
+        # Success, break out of retry loop
+        break
+    done
+
+    # If we exhausted retries and still have no content, log error and return empty
+    if [ -z "$page_content" ]; then
+        log_error "Could not fetch Fedora People Archive after $max_retries attempts"
+        echo '{"version":"","release":""}'
+        return 0
     fi
 
-    # Extraktion der Version und des Datums
+    # Extract version and date
     latest_json=$(echo "$page_content" | awk '
         /qemu-ga-win-[^"]+\// {
-            # Suche nach dem Versions-String (z.B. qemu-ga-win-9.1.0)
+            # Search for the version string (e.g. qemu-ga-win-9.1.0)
             if (match($0, /qemu-ga-win-[0-9]+\.[0-9]+\.[0-9]+/)) {
                 full_match = substr($0, RSTART, RLENGTH)
-                # Entferne den Präfix, um nur die Version zu behalten
+                # Remove the prefix to keep only the version
                 sub(/qemu-ga-win-/, "", full_match)
                 version = full_match
 
-                # Suche nach dem Datum (YYYY-MM-DD)
+                # Search for the date (YYYY-MM-DD)
                 if (match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/)) {
                     date = substr($0, RSTART, RLENGTH)
                     print version " " date
@@ -143,7 +187,9 @@ fetch_latest_qemu_ga_version() {
     )
 
     if [ -z "$latest_json" ]; then
-        log_error "Could not find any qemu-ga-win directory versions"
+        log_error "Could not find any qemu-ga-win directory versions in Fedora Archive"
+        echo '{"version":"","release":""}'
+        return 0
     fi
 
     echo "$latest_json"

--- a/lib/default.func
+++ b/lib/default.func
@@ -22,7 +22,13 @@
 # @example
 #   check_script_dependencies
 function check_script_dependencies() {
-    local dependencies=( "curl" "jq" "pvesh" "qm" "grep" "sed" "awk" "sort" "whiptail" )
+    local dependencies
+    if [[ "${CONTAINER_MODE:-false}" == "true" ]]; then
+        # pvesh and qm are replaced by pve-api.func shims; whiptail not needed headlessly
+        dependencies=( "curl" "jq" "grep" "sed" "awk" "sort" )
+    else
+        dependencies=( "curl" "jq" "pvesh" "qm" "grep" "sed" "awk" "sort" "whiptail" )
+    fi
     for dep in "${dependencies[@]}"; do
         if ! command -v "$dep" &> /dev/null; then
             log_fatal "Error: $dep is not installed."

--- a/lib/pve-interact.func
+++ b/lib/pve-interact.func
@@ -98,7 +98,8 @@ function get_windows_vms() {
 function get_windows_virtio_version() {
     local vmid=$1
     # Use guest-agent to get the VirtIO driver version inside the Windows VM
-    version=$(qm guest exec $vmid -- powershell.exe -Command 'Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*", "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" | Where-Object { $_.DisplayName } | Where-Object { $_.DisplayName -like "*virtio*installer*" } | Select-Object -ExpandProperty DisplayVersion' 2>/dev/null | jq -r '.["out-data"]' | tr -d '\r\n')
+    local ps_cmd='Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*", "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" | Where-Object { $_.DisplayName } | Where-Object { $_.DisplayName -like "*virtio*installer*" } | Select-Object -ExpandProperty DisplayVersion'
+    version=$(qm guest exec "$vmid" -- powershell.exe -Command "$ps_cmd" 2>/dev/null | jq -r '.["out-data"]' | tr -d '\r\n')
     echo "$version"
 }
 
@@ -111,7 +112,8 @@ function get_windows_virtio_version() {
 function get_windows_QEMU_GA_version() {
     local vmid=$1
     # Use guest-agent to get the QEMU Guest Agent driver version inside the Windows VM
-    version=$(qm guest exec $vmid -- powershell.exe -Command "\$qemuPaths = @('C:\\Program Files\\Qemu-ga\\qemu-ga.exe', 'C:\\Program Files (x86)\\Qemu-ga\\qemu-ga.exe'); foreach (\$path in \$qemuPaths) { if (Test-Path \$path) { (Get-Item \$path).VersionInfo.FileVersion } }" 2>/dev/null | jq -r '.["out-data"]' | tr -d '\r\n')
+    local ps_cmd='$qemuPaths = @("C:\\Program Files\\Qemu-ga\\qemu-ga.exe", "C:\\Program Files (x86)\\Qemu-ga\\qemu-ga.exe"); foreach ($path in $qemuPaths) { if (Test-Path $path) { (Get-Item $path).VersionInfo.FileVersion } }'
+    version=$(qm guest exec "$vmid" -- powershell.exe -Command "$ps_cmd" 2>/dev/null | jq -r '.["out-data"]' | tr -d '\r\n')
     echo "$version"
 }
 

--- a/lib/pve-interact.func
+++ b/lib/pve-interact.func
@@ -134,12 +134,13 @@ function update_vm_description_with_update_nag() {
     
     current_description=$(echo "$current_vm_config" | jq -r '.description // empty')
     
+    local nag_img_base="${NAG_IMAGE_BASE_URL:-/pve2/images}"
     local update_banner
     if [[ -n "${WEBHOOK_HOST:-}" && -n "${WEBHOOK_SECRET:-}" ]]; then
         local webhook_url="http://${WEBHOOK_HOST}:${WEBHOOK_PORT:-9000}/hooks/${vmid}?token=${WEBHOOK_SECRET}"
-        update_banner='<a href="'"$webhook_url"'" target="_blank"><img src="/pve2/images/update-'"$vmid"'.svg" alt="VirtIO Update - Click to Update" /></a>'
+        update_banner='<a href="'"$webhook_url"'" target="_blank"><img src="'"${nag_img_base}"'/update-'"$vmid"'.svg" alt="VirtIO Update - Click to Update" /></a>'
     else
-        update_banner='<img src="/pve2/images/update-'"$vmid"'.svg" alt="VirtIO Update" />'
+        update_banner='<img src="'"${nag_img_base}"'/update-'"$vmid"'.svg" alt="VirtIO Update" />'
     fi
     
     # Check if description exists and is not empty
@@ -183,8 +184,9 @@ function remove_vm_nag() {
         return 0
     fi
     
-    # Remove the nag banner (handles both plain <img/> and <a><img/></a> forms) and separator
-    local new_description=$(echo "$current_description" | sed -E "s|(<a[^>]*>)?<img src=\"/pve2/images/update-$vmid\.svg\"[^>]*/>(</a>)?(<hr/>)?||g")
+    # Remove the nag banner (handles both plain <img/> and <a><img/></a> forms) and separator.
+    # The src pattern matches any base URL so bare-metal and container paths are both handled.
+    local new_description=$(echo "$current_description" | sed -E "s|(<a[^>]*>)?<img src=\"[^\"]*update-$vmid\.svg\"[^>]*/>(</a>)?(<hr/>)?||g")
     
     # Clean up any leftover empty lines or double separators
     new_description=$(echo "$new_description" | sed -E 's|<hr/>(<hr/>)+|<hr/>|g' | sed -E 's|^<hr/>||' | sed -E 's|<hr/>$||')

--- a/lib/svg-nag.func
+++ b/lib/svg-nag.func
@@ -14,7 +14,7 @@
 #   - build_svg_virtio_update_nag: Create SVG banner for VirtIO updates only
 #   - build_svg_qemu_ga_update_nag: Create SVG banner for QEMU GA updates only
 
-SVG_IMAGE_PATH="/usr/share/pve-manager/images/"
+SVG_IMAGE_PATH="${SVG_IMAGE_PATH:-/usr/share/pve-manager/images/}"
 SVG_IMAGE_TEMPLATE="${SCRIPT_DIR}/templates/svg/update-nag-template.svg"
 SVG_IMAGE_TEMPLATE_BOTH="${SCRIPT_DIR}/templates/svg/update-nag-both-template.svg"
 

--- a/lib/svg-nag.func
+++ b/lib/svg-nag.func
@@ -14,7 +14,7 @@
 #   - build_svg_virtio_update_nag: Create SVG banner for VirtIO updates only
 #   - build_svg_qemu_ga_update_nag: Create SVG banner for QEMU GA updates only
 
-SVG_IMAGE_PATH="${SVG_IMAGE_PATH:-/usr/share/pve-manager/images/}"
+SVG_IMAGE_PATH="${SVG_IMAGE_PATH:-/usr/share/pve-manager/images}"
 SVG_IMAGE_TEMPLATE="${SCRIPT_DIR}/templates/svg/update-nag-template.svg"
 SVG_IMAGE_TEMPLATE_BOTH="${SCRIPT_DIR}/templates/svg/update-nag-both-template.svg"
 


### PR DESCRIPTION
## Summary
This PR adds full Docker containerization support to PVE-QEMU-VirtIO-Updater, enabling the application to run in isolated containers while communicating with Proxmox VE via its REST API instead of requiring direct CLI access.

## Key Changes

- **New Docker infrastructure**
  - `Dockerfile`: Multi-stage build with curl, jq, cron, and standard utilities
  - `docker-compose.yml`: Orchestrates updater and Caddy reverse-proxy services
  - `Caddyfile`: Serves SVG nag images with optional HTTPS/domain support
  - `entrypoint.sh`: Container startup script that runs update checks on a configurable interval

- **REST API shim layer** (`docker/lib/pve-api.func`)
  - Implements `pvesh` and `qm` command shims that call Proxmox REST API over HTTPS
  - Supports `pvesh get <path>` for querying cluster state
  - Supports `qm guest exec <vmid> -- <cmd>` for executing commands in VMs with polling
  - Supports `qm set <vmid> -description <value>` for updating VM descriptions
  - Uses PVEAPIToken authentication (token-based, no password required)
  - Automatically loaded only in container mode via glob pattern in check-vm-updates.sh

- **Configuration updates**
  - Extended `.env.example` with container mode settings:
    - `CONTAINER_MODE`: Enable/disable container shims
    - `PVE_HOST`, `PVE_PORT`, `PVE_API_TOKEN_ID`, `PVE_API_TOKEN_SECRET`: API credentials
    - `NAG_IMAGE_BASE_URL`: Configurable image serving endpoint (defaults to `/pve2/images` on bare metal)
    - `SVG_IMAGE_PATH`: Container-specific image output directory
    - `UPDATER_INTERVAL`: Configurable check frequency

- **Conditional dependency checking** (`lib/default.func`)
  - Container mode skips `pvesh`, `qm`, and `whiptail` dependency checks
  - Bare-metal mode retains all original dependencies

- **Dynamic image URL handling** (`lib/pve-interact.func`, `lib/svg-nag.func`)
  - `NAG_IMAGE_BASE_URL` environment variable replaces hardcoded `/pve2/images` paths
  - Allows SVG nag images to be served from external sources (e.g., Caddy container)
  - Maintains backward compatibility with bare-metal `/pve2/images` default

## Implementation Details

- **Guard pattern**: pve-api.func checks `CONTAINER_MODE=true` before activating shims; bare-metal installations are unaffected
- **API polling**: `qm guest exec` polls `/agent/exec-status` with 60-second timeout to match real qm behavior
- **URL encoding**: Custom `_pve_url_encode()` function handles special characters in POST/PUT bodies
- **Node resolution**: Shims look up VM node placement from the global `$windows_vms` JSON structure
- **Error handling**: All shims log errors via `log_error()` and return non-zero on failure
- **Volume mounts**: Shared `images` volume between updater and Caddy for SVG serving

## Backward Compatibility
- Bare-metal PVE hosts are completely unaffected; pve-api.func is only present in Docker images
- All existing environment variables and configurations continue to work
- Default behavior (without `CONTAINER_MODE=true`) is identical to previous releases